### PR TITLE
Add orts/world as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data/world"]
+	path = data/world
+	url = https://github.com/orts/world.git


### PR DESCRIPTION
This should ease getting both the datapack and the huge map together. If someone wants to get both, instead of cloning two projects, one could run `git clone --recursive orts/server` and the `orts/world` would be fetched too, but it is optional and any map can be used by cloning normally.

You can also run `git submodule init` then `git submodule update` to fetch the world after cloning without the `--recursive` option. [Check more about submodules](https://chrisjean.com/git-submodules-adding-using-removing-and-updating/).