### PR TITLE
Fixed bug in the spawning of NPC Rashid

### DIFF
--- a/data/globalevents/scripts/spawn/RashidSpawn.lua
+++ b/data/globalevents/scripts/spawn/RashidSpawn.lua
@@ -18,9 +18,8 @@ function onStartup()
 			npc:setMasterPos(config[os.date('%A')])
 		end
 	else
-		local npc, position
-		for i = 1, #config do
-			position = config[i]
+		local npc
+		for k, position in pairs(config) do
 			npc = Game.createNpc('Rashid', position, false, true)
 			if npc then
 				npc:setMasterPos(position)

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -25533,7 +25533,7 @@
 		<attribute key="weight" value="105" />
 		<attribute key="slotType" value="ring" />
 		<attribute key="absorbPercentPhysical" value="10" />
-		<attribute key="absorbPercentEarth" value="8" />
+		<attribute key="absorbPercentEnergy" value="8" />
 		<attribute key="transformDeEquipTo" value="18408" />
 		<attribute key="decayTo" value="0" />
 		<attribute key="duration" value="3600" />


### PR DESCRIPTION
If spawnByDay is set to false, the loop will fail to spawn NPC Rashid at
every position. Also we don't have to worry about the order here.