### PR TITLE
Fixed bug in Demon Oak

### DIFF
--- a/data/actions/scripts/quests/demon oak/demonOak.lua
+++ b/data/actions/scripts/quests/demon oak/demonOak.lua
@@ -64,8 +64,8 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	local totalProgress = 0
-	for i = 1, #config.storages do
-		totalProgress = totalProgress + math.max(0, player:getStorageValue(config.storages[i]))
+	for k,v in pairs(config.storages) do
+		totalProgress = totalProgress + math.max(0, player:getStorageValue(v))
 	end
 
 	local spectators, hasMonsters = Game.getSpectators(DEMON_OAK_POSITION, false, false, 9, 9, 6, 6), false


### PR DESCRIPTION
Fixed where script fails to iterate config.storages in order to
calculate total progress in the quest.