### PR TITLE
Added world as a proper git submodule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,4 +224,3 @@ theforgottenserver.exe
 zlib1.dll
 realmap.otbm
 map.rar
-data/world/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data/world"]
+	path = data/world
+	url = https://github.com/orts/world.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "data/world"]
-	path = data/world
-	url = https://github.com/orts/world.git


### PR DESCRIPTION
If you wish to pull the world repository for a new repo add the `--recursive` flag
`git clone --recursive https://github.com/orts/server.git`
 
If the repo is already cloned, you can run the following instead:
`git submodule update --init --recursive`

To update the world in the future you need to run:
`git pull --recurse-submodules`

You should still do all of your map commits in the world repository.
This is just better for developers that want the full datapack but aren't doing world updates and only care about the latest (or specific) revision of the world and not all the world history which can take up a lot of space and time syncing.