### PR TITLE
Fix so you can start inquisition by saying mission to Henricus

### DIFF
--- a/data/npc/scripts/Henricus.lua
+++ b/data/npc/scripts/Henricus.lua
@@ -30,7 +30,10 @@ local function creatureSayCallback(cid, type, msg)
 			npcHandler.topic[cid] = 0
 		end
 	elseif msgcontains(msg, "mission") or msgcontains(msg, "report") then
-		if player:getStorageValue(Storage.TheInquisition.Questline) == 1 then
+		if player:getStorageValue(Storage.TheInquisition.Questline) < 1 then
+			npcHandler:say("Do you want to join the inquisition?", cid)
+			npcHandler.topic[cid] = 2
+		elseif player:getStorageValue(Storage.TheInquisition.Questline) == 1 then
 			npcHandler:say({
 				"Let's see if you are worthy. Take an inquisitor's field guide from the box in the back room. ...",
 				"Follow the instructions in the guide to talk to the Thaian guards that protect the walls and gates of the city and test their loyalty. Then report to me about your {mission}."


### PR DESCRIPTION
This will allow you to start the inquisition by saying "mission" to Henricus, checked in real that it should work with both "mission" and "join", transcripts from real:
> 15:08 Player [23]: mission
> 15:08 Henricus: Do you want to join the inquisition?
> 15:08 Player [23]: join
> 15:08 Henricus: Do you want to join the inquisition?